### PR TITLE
Add compatibility with EDD 3.0

### DIFF
--- a/includes/class-process-redirects.php
+++ b/includes/class-process-redirects.php
@@ -42,10 +42,10 @@ class EDD_Conditional_Success_Redirects_Process_Redirects {
 				$payment_id = edd_get_purchase_id_by_key( $session['purchase_key'] );
 			}
 
-			$payment = get_post( $payment_id );
+			$payment = edd_get_payment( $payment_id );
 
 			// if payment is pending or private (buy now button behavior), load the payment processing template
-			if ( $payment && ( 'pending' == $payment->post_status || 'private' == $payment->post_status ) ) {
+			if ( $payment && ( 'pending' == edd_get_payment_status( $payment ) || 'private' == $payment->status ) ) {
 
 				// Payment is still pending or private so show processing indicator to fix the Race Condition
 				ob_start();
@@ -55,7 +55,7 @@ class EDD_Conditional_Success_Redirects_Process_Redirects {
 
 				$content = ob_get_clean();
 
-			} elseif ( $payment && 'publish' == $payment->post_status ) {
+			} elseif ( $payment && edd_is_payment_complete( $payment->ID) ) {
 
 				$redirect_url = $this->get_redirect();
 


### PR DESCRIPTION
Two important notes here:

1. This change is not tested as it affects code that works only when it's paid via PayPal.
2. I'm not sure about payment statuses for two reasons:
	1. When I look `edd_get_payment_statuses()`, there is no `'private'` status. So when checking if payment has `'private'` status, I do check `status` property of payment object instead of using `edd_get_payment_status()` function. 
	2. When you use `EDD_Payment::update_status()`, `'publish` status is changed to `'complete'`, and when you look at `edd_is_payment_complete()`, it checks only if it's `'complete'`. But what about older payments, made before EDD 3.0?